### PR TITLE
Update default open state for TutorAvailabilitySection components

### DIFF
--- a/apps/mobile/src/app/components/tutor-profile/TutorAvailabilitySection.tsx
+++ b/apps/mobile/src/app/components/tutor-profile/TutorAvailabilitySection.tsx
@@ -87,7 +87,7 @@ export function TutorAvailabilitySection({ tutor, onOpenRateCard }: Props) {
   const canSet = tutor.canSetAvailability === true;
   const hasRateCard = tutorHasAtLeastOneCompleteRateCard(tutor.offerings);
   const unlocked = canSet && hasRateCard;
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
   const rangeEditor = useAvailabilityEditor({ loadedSlots: [], loading: false });

--- a/libs/tutor-availability-ui/src/TutorAvailabilitySection.tsx
+++ b/libs/tutor-availability-ui/src/TutorAvailabilitySection.tsx
@@ -33,7 +33,7 @@ const CALENDAR_STYLES = {
 
 function CollapsibleSectionCard({
   title,
-  defaultOpen = true,
+  defaultOpen = false,
   variant = 'unlocked',
   updatedTillLabel,
   updatedTillLoading = false,


### PR DESCRIPTION
- Changed the initial state of the availability section from open to closed in both mobile and UI library components.
- This adjustment improves user experience by requiring explicit action to view availability settings.