### PR TITLE
Add Tutor Calendar Queries and Update Tutor Availability Components

### DIFF
--- a/apps/api/src/app/modules/admin/admin.module.ts
+++ b/apps/api/src/app/modules/admin/admin.module.ts
@@ -8,6 +8,7 @@ import { ExperienceModule } from '../experience/experience.module';
 import { OfferingsModule } from '../offerings/offerings.module';
 import { ProficiencyModule } from '../proficiency/proficiency.module';
 import { TutorModule } from '../tutor/tutor.module';
+import { TutorCalendarModule } from '../tutor-calendar/tutor-calendar.module';
 import { AdminService } from './admin.service';
 import { AdminResolver } from './admin.resolver';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -17,6 +18,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
     TypeOrmModule.forFeature([User, Tutor]),
     AuthModule,
     TutorModule,
+    TutorCalendarModule,
     ExperienceModule,
     DocumentModule,
     ProficiencyModule,

--- a/apps/api/src/app/modules/admin/admin.resolver.ts
+++ b/apps/api/src/app/modules/admin/admin.resolver.ts
@@ -16,10 +16,15 @@ import { AdminTutorListResult } from './dto/admin-tutor-list-result.dto';
 import { AdminTutorStageCount } from './dto/admin-tutor-stage-count.dto';
 import { AdminProficiencyTestListItem } from './dto/admin-proficiency-test-list-item.dto';
 import { ProficiencyTestEntity } from '../proficiency/entities/proficiency-test.entity';
+import { TutorCalendar } from '../tutor-calendar/entities/tutor-calendar.entity';
+import { TutorCalendarService } from '../tutor-calendar/services/tutor-calendar.service';
 
 @Resolver()
 export class AdminResolver {
-  constructor(private readonly adminService: AdminService) {}
+  constructor(
+    private readonly adminService: AdminService,
+    private readonly tutorCalendarService: TutorCalendarService,
+  ) {}
 
   @Query(() => AdminDashboardStats, {
     description: 'Signup counts for admin dashboard (admin only)',
@@ -61,6 +66,33 @@ export class AdminResolver {
     @Args('tutorId', { type: () => Int }) tutorId: number,
   ): Promise<AdminTutorDetail> {
     return this.adminService.getTutorDetail(tutorId);
+  }
+
+  @Query(() => [TutorCalendar], {
+    description:
+      'Available teaching slots for a tutor within a date range (admin only)',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  async adminTutorCalendar(
+    @Args('tutorId', { type: () => Int }) tutorId: number,
+    @Args('from') from: Date,
+    @Args('to') to: Date,
+  ): Promise<TutorCalendar[]> {
+    return this.tutorCalendarService.getAdminCalendar(tutorId, from, to);
+  }
+
+  @Query(() => Date, {
+    nullable: true,
+    description:
+      'Latest available slot start for a tutor, or null if none (admin only)',
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  async adminTutorCalendarUpdatedTill(
+    @Args('tutorId', { type: () => Int }) tutorId: number,
+  ): Promise<Date | null> {
+    return this.tutorCalendarService.getAdminCalendarUpdatedTill(tutorId);
   }
 
   @Mutation(() => AdminTutorDocumentDetail, {

--- a/apps/api/src/app/modules/tutor-calendar/services/tutor-calendar.service.ts
+++ b/apps/api/src/app/modules/tutor-calendar/services/tutor-calendar.service.ts
@@ -89,10 +89,33 @@ export class TutorCalendarService {
   ): Promise<Date | null> {
     const tutor = await this.requireTutorForUser(userId);
     await this.assertCanSetCalendar(tutor.id);
+    return this.getLatestSlotStartForTutor(tutor.id);
+  }
+
+  async getAdminCalendar(
+    tutorId: number,
+    from: Date,
+    to: Date,
+  ): Promise<TutorCalendar[]> {
+    await this.requireTutorById(tutorId);
+    if (to <= from) {
+      throw new BadRequestException('Invalid date range');
+    }
+    return this.findForTutorInRange(tutorId, from, to);
+  }
+
+  async getAdminCalendarUpdatedTill(tutorId: number): Promise<Date | null> {
+    await this.requireTutorById(tutorId);
+    return this.getLatestSlotStartForTutor(tutorId);
+  }
+
+  private async getLatestSlotStartForTutor(
+    tutorId: number,
+  ): Promise<Date | null> {
     const row = await this.calendarRepo
       .createQueryBuilder('c')
       .select('MAX(c.startsAt)', 'maxStartsAt')
-      .where('c.tutorId = :tutorId', { tutorId: tutor.id })
+      .where('c.tutorId = :tutorId', { tutorId })
       .andWhere('c.deleted = false')
       .getRawOne<{ maxStartsAt: Date | string | null }>();
     if (row?.maxStartsAt == null) return null;
@@ -185,6 +208,16 @@ export class TutorCalendarService {
     }
 
     return this.findForTutorInRange(tutor.id, rangeStart, rangeEnd);
+  }
+
+  private async requireTutorById(tutorId: number): Promise<Tutor> {
+    const tutor = await this.tutorRepo.findOne({
+      where: { id: tutorId, deleted: false },
+    });
+    if (!tutor) {
+      throw new NotFoundException('Tutor not found');
+    }
+    return tutor;
   }
 
   private async requireTutorForUser(userId: number): Promise<Tutor> {

--- a/libs/shared-graphql/src/queries/admin.queries.ts
+++ b/libs/shared-graphql/src/queries/admin.queries.ts
@@ -55,6 +55,8 @@ export const GET_ADMIN_TUTOR_DETAIL = gql`
       yearsOfExperience
       regFeePaid
       testTutor
+      canSetAvailability
+      availabilityConfiguredAt
       regFeeAmount
       regFeeAmountToBePaid
       regFeeDate

--- a/libs/shared-graphql/src/queries/tutor-calendar.queries.ts
+++ b/libs/shared-graphql/src/queries/tutor-calendar.queries.ts
@@ -15,3 +15,19 @@ export const GET_MY_TUTOR_CALENDAR_UPDATED_TILL = gql`
     myTutorCalendarUpdatedTill
   }
 `;
+
+export const GET_ADMIN_TUTOR_CALENDAR = gql`
+  query GetAdminTutorCalendar($tutorId: Int!, $from: DateTime!, $to: DateTime!) {
+    adminTutorCalendar(tutorId: $tutorId, from: $from, to: $to) {
+      id
+      startsAt
+      durationMinutes
+    }
+  }
+`;
+
+export const GET_ADMIN_TUTOR_CALENDAR_UPDATED_TILL = gql`
+  query GetAdminTutorCalendarUpdatedTill($tutorId: Int!) {
+    adminTutorCalendarUpdatedTill(tutorId: $tutorId)
+  }
+`;

--- a/libs/tutor-availability-ui/src/TutorAvailabilityCalendar.tsx
+++ b/libs/tutor-availability-ui/src/TutorAvailabilityCalendar.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useMutation, useQuery } from '@apollo/client';
 import {
+  GET_ADMIN_TUTOR_CALENDAR,
+  GET_ADMIN_TUTOR_CALENDAR_UPDATED_TILL,
   GET_MY_TUTOR_CALENDAR,
   GET_MY_TUTOR_CALENDAR_UPDATED_TILL,
   SAVE_MY_TUTOR_CALENDAR,
@@ -13,14 +15,23 @@ import {
 import { useAvailabilityEditor, type CalendarSlotRow } from './useAvailabilityEditor';
 
 export type TutorAvailabilityCalendarProps = {
+  /** When set, loads calendar for this tutor via admin queries (read-only in admin UI). */
+  tutorId?: number;
+  readOnly?: boolean;
   onSaveError?: (message: string | null) => void;
   onUpdatedTill?: (info: { label: string | null; loading: boolean }) => void;
 };
 
 export function TutorAvailabilityCalendar({
+  tutorId,
+  readOnly = false,
   onSaveError,
   onUpdatedTill,
 }: TutorAvailabilityCalendarProps) {
+  const isAdminView = tutorId != null && Number.isFinite(tutorId);
+  const interactive = !readOnly;
+  const adminTutorId = isAdminView ? tutorId : undefined;
+
   const gestureRef = useRef<{
     active: boolean;
     paintAdd: boolean;
@@ -29,18 +40,39 @@ export function TutorAvailabilityCalendar({
   const blockClickRef = useRef(false);
   const rangeProbe = useAvailabilityEditor({ loadedSlots: [], loading: false });
 
-  const { data, loading, refetch } = useQuery(GET_MY_TUTOR_CALENDAR, {
-    variables: { from: rangeProbe.rangeStart, to: rangeProbe.rangeEnd },
-    fetchPolicy: 'network-only',
-  });
+  const calendarQueryVariables =
+    isAdminView && adminTutorId != null
+      ? {
+          tutorId: adminTutorId,
+          from: rangeProbe.rangeStart,
+          to: rangeProbe.rangeEnd,
+        }
+      : { from: rangeProbe.rangeStart, to: rangeProbe.rangeEnd };
+
+  const { data, loading, refetch } = useQuery(
+    isAdminView ? GET_ADMIN_TUTOR_CALENDAR : GET_MY_TUTOR_CALENDAR,
+    {
+      variables: calendarQueryVariables,
+      fetchPolicy: 'network-only',
+      skip: isAdminView && adminTutorId == null,
+    },
+  );
 
   const {
     data: updatedTillData,
     loading: updatedTillLoading,
     refetch: refetchUpdatedTill,
-  } = useQuery(GET_MY_TUTOR_CALENDAR_UPDATED_TILL, {
-    fetchPolicy: 'network-only',
-  });
+  } = useQuery(
+    isAdminView
+      ? GET_ADMIN_TUTOR_CALENDAR_UPDATED_TILL
+      : GET_MY_TUTOR_CALENDAR_UPDATED_TILL,
+    {
+      variables:
+        isAdminView && adminTutorId != null ? { tutorId: adminTutorId } : undefined,
+      fetchPolicy: 'network-only',
+      skip: isAdminView && adminTutorId == null,
+    },
+  );
 
   useEffect(() => {
     if (!onUpdatedTill) return;
@@ -48,18 +80,23 @@ export function TutorAvailabilityCalendar({
       onUpdatedTill({ label: null, loading: true });
       return;
     }
-    const raw = updatedTillData?.myTutorCalendarUpdatedTill;
+    const raw = isAdminView
+      ? updatedTillData?.adminTutorCalendarUpdatedTill
+      : updatedTillData?.myTutorCalendarUpdatedTill;
     const label = raw ? formatAvailabilityUpdatedTill(new Date(raw)) : null;
     onUpdatedTill({ label, loading: false });
-  }, [onUpdatedTill, updatedTillData, updatedTillLoading]);
+  }, [isAdminView, onUpdatedTill, updatedTillData, updatedTillLoading]);
 
-  const loadedSlots: CalendarSlotRow[] = data?.myTutorCalendar ?? [];
+  const loadedSlots: CalendarSlotRow[] = isAdminView
+    ? (data?.adminTutorCalendar ?? [])
+    : (data?.myTutorCalendar ?? []);
 
   const ui = useAvailabilityEditor({ loadedSlots, loading });
 
   const [saveCalendar, { loading: saving }] = useMutation(SAVE_MY_TUTOR_CALENDAR);
 
   useEffect(() => {
+    if (!interactive) return;
     const onUp = () => {
       gestureRef.current = null;
       blockClickRef.current = true;
@@ -69,23 +106,23 @@ export function TutorAvailabilityCalendar({
     };
     window.addEventListener('mouseup', onUp);
     return () => window.removeEventListener('mouseup', onUp);
-  }, []);
+  }, [interactive]);
 
   const paintCell = useCallback(
     (key: string, disabled: boolean) => {
-      if (disabled) return;
+      if (!interactive || disabled) return;
       const gesture = gestureRef.current;
       if (!gesture?.active) return;
       if (gesture.visited.has(key)) return;
       gesture.visited.add(key);
       ui.toggleKey(key, gesture.paintAdd);
     },
-    [ui],
+    [interactive, ui],
   );
 
   const startPaintGesture = useCallback(
     (key: string, disabled: boolean, paintAdd: boolean) => {
-      if (disabled) return;
+      if (!interactive || disabled) return;
       gestureRef.current = {
         active: true,
         paintAdd,
@@ -93,7 +130,7 @@ export function TutorAvailabilityCalendar({
       };
       paintCell(key, disabled);
     },
-    [paintCell],
+    [interactive, paintCell],
   );
 
   const handleSave = async () => {
@@ -184,14 +221,20 @@ export function TutorAvailabilityCalendar({
                     key={`${slot.hour}-${slot.minute}`}
                     className="border-b border-slate-200 bg-slate-50 px-0.5 py-1 text-center font-medium text-slate-600"
                   >
-                    <button
-                      type="button"
-                      className="w-full text-[9px] leading-tight hover:text-sky-700 hover:underline"
-                      onClick={() => ui.toggleTimeColumn(timeIndex)}
-                      title="Toggle this time for all days this week"
-                    >
-                      {formatSlotTimeLabel(slot.hour, slot.minute)}
-                    </button>
+                    {interactive ? (
+                      <button
+                        type="button"
+                        className="w-full text-[9px] leading-tight hover:text-sky-700 hover:underline"
+                        onClick={() => ui.toggleTimeColumn(timeIndex)}
+                        title="Toggle this time for all days this week"
+                      >
+                        {formatSlotTimeLabel(slot.hour, slot.minute)}
+                      </button>
+                    ) : (
+                      <span className="block text-[9px] leading-tight">
+                        {formatSlotTimeLabel(slot.hour, slot.minute)}
+                      </span>
+                    )}
                   </th>
                 ))}
               </tr>
@@ -202,33 +245,42 @@ export function TutorAvailabilityCalendar({
                 return (
                   <tr key={day.toISOString()}>
                     <td className="sticky left-0 z-10 border-r border-slate-100 bg-slate-50 px-1 py-1 text-slate-700">
-                      <button
-                        type="button"
-                        className="block text-left text-[11px] font-medium leading-tight hover:text-sky-700 hover:underline"
-                        onClick={() => ui.toggleDayRow(dayIndex)}
-                        title="Toggle all times for this day"
-                      >
-                        {formatIstDayHeader(day)}
-                      </button>
-                      <button
-                        type="button"
-                        className="mt-0.5 block text-[9px] font-normal text-sky-600 hover:underline"
-                        onClick={() => ui.clearDay(dayIndex)}
-                      >
-                        Clear
-                      </button>
+                      {interactive ? (
+                        <>
+                          <button
+                            type="button"
+                            className="block text-left text-[11px] font-medium leading-tight hover:text-sky-700 hover:underline"
+                            onClick={() => ui.toggleDayRow(dayIndex)}
+                            title="Toggle all times for this day"
+                          >
+                            {formatIstDayHeader(day)}
+                          </button>
+                          <button
+                            type="button"
+                            className="mt-0.5 block text-[9px] font-normal text-sky-600 hover:underline"
+                            onClick={() => ui.clearDay(dayIndex)}
+                          >
+                            Clear
+                          </button>
+                        </>
+                      ) : (
+                        <span className="block text-left text-[11px] font-medium leading-tight">
+                          {formatIstDayHeader(day)}
+                        </span>
+                      )}
                     </td>
                     {dayCells.map((cell) => {
                       const selected = ui.selectedKeys.has(cell.key);
+                      const cellDisabled = cell.disabled || !interactive;
                       return (
                         <td
                           key={cell.key}
                           className="border-b border-slate-50 p-0.5 text-center"
-                          onMouseEnter={() => paintCell(cell.key, cell.disabled)}
+                          onMouseEnter={() => paintCell(cell.key, cellDisabled)}
                         >
                           <button
                             type="button"
-                            disabled={cell.disabled}
+                            disabled={cellDisabled}
                             aria-pressed={selected}
                             aria-label={
                               selected
@@ -240,18 +292,22 @@ export function TutorAvailabilityCalendar({
                             className={`mx-auto flex h-5 w-5 items-center justify-center rounded border text-[10px] font-bold transition-colors ${
                               cell.disabled
                                 ? 'cursor-not-allowed border-transparent bg-slate-100 opacity-40'
-                                : selected
-                                  ? 'border-emerald-600 bg-emerald-500 text-white hover:bg-emerald-600'
-                                  : 'border-slate-300 bg-white text-transparent hover:border-sky-400'
+                                : !interactive
+                                  ? selected
+                                    ? 'cursor-default border-emerald-600 bg-emerald-500 text-white'
+                                    : 'cursor-default border-slate-300 bg-white text-transparent'
+                                  : selected
+                                    ? 'border-emerald-600 bg-emerald-500 text-white hover:bg-emerald-600'
+                                    : 'border-slate-300 bg-white text-transparent hover:border-sky-400'
                             }`}
                             onMouseDown={(e) => {
-                              if (cell.disabled) return;
+                              if (cellDisabled) return;
                               e.preventDefault();
-                              startPaintGesture(cell.key, cell.disabled, !selected);
+                              startPaintGesture(cell.key, cellDisabled, !selected);
                             }}
-                            onMouseEnter={() => paintCell(cell.key, cell.disabled)}
+                            onMouseEnter={() => paintCell(cell.key, cellDisabled)}
                             onClick={(e) => {
-                              if (cell.disabled) return;
+                              if (cellDisabled) return;
                               if (blockClickRef.current) {
                                 e.preventDefault();
                                 return;
@@ -272,21 +328,23 @@ export function TutorAvailabilityCalendar({
         </div>
       )}
 
-      <div className="flex flex-wrap items-center gap-3">
-        {ui.isDirty ? (
-          <span className="text-sm text-amber-700">Unsaved changes</span>
-        ) : (
-          <span className="text-sm text-slate-500">All changes saved</span>
-        )}
-        <button
-          type="button"
-          disabled={!ui.isDirty || saving || loading}
-          onClick={() => void handleSave()}
-          className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {saving ? 'Saving…' : 'Save'}
-        </button>
-      </div>
+      {interactive ? (
+        <div className="flex flex-wrap items-center gap-3">
+          {ui.isDirty ? (
+            <span className="text-sm text-amber-700">Unsaved changes</span>
+          ) : (
+            <span className="text-sm text-slate-500">All changes saved</span>
+          )}
+          <button
+            type="button"
+            disabled={!ui.isDirty || saving || loading}
+            onClick={() => void handleSave()}
+            className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/libs/tutor-availability-ui/src/TutorAvailabilitySection.tsx
+++ b/libs/tutor-availability-ui/src/TutorAvailabilitySection.tsx
@@ -10,6 +10,13 @@ export type TutorAvailabilitySectionProps = {
   canSetAvailability: boolean;
   offerings: TutorDetailOffering[];
   onOpenRateCard?: (offering: TutorDetailOffering) => void;
+  /** Admin detail: load this tutor's calendar (read-only). */
+  tutorId?: number;
+  readOnly?: boolean;
+  /** Section title; defaults to "My Calendar" or "Tutor calendar" when read-only. */
+  title?: string;
+  /** When true, hide the section entirely if rate card / offering requirements are not met. */
+  hideWhenLocked?: boolean;
 };
 
 const CALENDAR_STYLES = {
@@ -99,6 +106,10 @@ export function TutorAvailabilitySection({
   canSetAvailability,
   offerings,
   onOpenRateCard,
+  tutorId,
+  readOnly = false,
+  title,
+  hideWhenLocked = false,
 }: TutorAvailabilitySectionProps) {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [updatedTillLabel, setUpdatedTillLabel] = useState<string | null>(null);
@@ -107,15 +118,23 @@ export function TutorAvailabilitySection({
     () => tutorHasAtLeastOneCompleteRateCard(offerings),
     [offerings],
   );
-  const unlocked = canSetAvailability && hasLocalRateCard;
+  const hasOfferings = offerings.length > 0;
+  const unlocked =
+    hasOfferings && hasLocalRateCard && (readOnly || canSetAvailability);
+
+  const sectionTitle =
+    title ?? (readOnly ? 'Tutor calendar' : 'My Calendar');
 
   const firstOfferingNeedingRate = offerings.find(
     (o) => !tutorHasAtLeastOneCompleteRateCard([o]),
   );
 
   if (!unlocked) {
+    if (hideWhenLocked) {
+      return null;
+    }
     return (
-      <CollapsibleSectionCard title="My Calendar" variant="locked">
+      <CollapsibleSectionCard title={sectionTitle} variant="locked">
         <p className="text-sm text-amber-900/90">{RATE_CARD_REQUIRED_MESSAGE}</p>
         {firstOfferingNeedingRate && onOpenRateCard ? (
           <button
@@ -132,15 +151,24 @@ export function TutorAvailabilitySection({
 
   return (
     <CollapsibleSectionCard
-      title="My Calendar"
+      title={sectionTitle}
+      defaultOpen={false}
       updatedTillLabel={updatedTillLabel}
       updatedTillLoading={updatedTillLoading}
     >
-      <p className="mb-4 text-sm text-teal-900/80">
-        Click a slot to mark available (A). Empty slots are not offered to students.
-        Each slot is a 1-hour class.
-      </p>
+      {!readOnly ? (
+        <p className="mb-4 text-sm text-teal-900/80">
+          Click a slot to mark available (A). Empty slots are not offered to students.
+          Each slot is a 1-hour class.
+        </p>
+      ) : (
+        <p className="mb-4 text-sm text-teal-900/80">
+          View-only schedule. Green slots (A) are when this tutor is available for classes.
+        </p>
+      )}
       <TutorAvailabilityCalendar
+        tutorId={tutorId}
+        readOnly={readOnly}
         onSaveError={setSaveError}
         onUpdatedTill={({ label, loading }) => {
           setUpdatedTillLabel(label);

--- a/libs/tutor-detail-ui/src/TutorDetailView.tsx
+++ b/libs/tutor-detail-ui/src/TutorDetailView.tsx
@@ -12,6 +12,7 @@ import {
   ptStatusLabel,
   sortQualificationsHighestFirst,
   sumExperienceDurations,
+  tutorHasAtLeastOneCompleteRateCard,
 } from '@tutorix/shared-utils';
 import { OfferingLabel } from './OfferingLabel';
 import { OnboardingTimeline } from './OnboardingTimeline';
@@ -541,6 +542,13 @@ export function TutorDetailView({
 
   const feeAmount = tutor.regFeePaid ? tutor.regFeeAmount : tutor.regFeeAmountToBePaid;
 
+  const showTutorCalendar = useMemo(
+    () =>
+      tutor.offerings.length > 0 &&
+      tutorHasAtLeastOneCompleteRateCard(tutor.offerings),
+    [tutor.offerings],
+  );
+
   return (
     <div className="space-y-6">
       <div className="overflow-hidden rounded-2xl border border-primary/10 bg-gradient-to-r from-sky-100/80 via-white to-violet-100/80 px-6 py-5 shadow-md shadow-sky-100/30">
@@ -660,53 +668,28 @@ export function TutorDetailView({
         </>
       )}
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <OnboardingTimeline entries={timelineEntries} />
-
-        <SectionCard title="Registration fee" styleKey="fee">
-          <dl className="grid gap-2.5 text-sm">
-            <DetailRow
-              label="Status"
-              accentClass="bg-amber-50/80"
-              value={
-                <span
-                  className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-bold ${
-                    tutor.regFeePaid
-                      ? 'bg-emerald-500 text-white'
-                      : 'bg-slate-200 text-slate-700'
-                  }`}
-                >
-                  {tutor.regFeePaid ? 'Paid' : 'Not received'}
-                </span>
-              }
-            />
-            <DetailRow
-              label="Amount"
-              value={feeAmount != null ? `₹${feeAmount}` : '—'}
-              accentClass="bg-amber-50/80"
-            />
-            <DetailRow
-              label="Date received"
-              value={tutor.regFeePaid ? formatDate(tutor.regFeeDate) : 'Not received'}
-              accentClass="bg-amber-50/80"
-            />
-          </dl>
-        </SectionCard>
-      </div>
-
       {isAdmin && (
         <>
+          {showTutorCalendar ? (
+            <TutorAvailabilitySection
+              canSetAvailability={tutor.canSetAvailability === true}
+              offerings={tutor.offerings}
+              tutorId={tutor.id}
+              readOnly
+              hideWhenLocked
+            />
+          ) : null}
+          <OfferingsSection
+            offerings={tutor.offerings}
+            mode={mode}
+            onOpenRateCard={(offering) => setRateCardOffering(offering)}
+          />
           <BankDetailsSection mode={mode} bankDetails={tutor.user?.bankDetails} />
           <AddressSection addresses={tutor.addresses} />
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             <EducationSection qualifications={tutor.qualifications} />
             <ExperienceSection experiences={tutor.experiences} />
           </div>
-          <OfferingsSection
-            offerings={tutor.offerings}
-            mode={mode}
-            onOpenRateCard={(offering) => setRateCardOffering(offering)}
-          />
         </>
       )}
 
@@ -749,6 +732,40 @@ export function TutorDetailView({
           </div>
         )}
       </SectionCard>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <OnboardingTimeline entries={timelineEntries} />
+
+        <SectionCard title="Registration fee" styleKey="fee">
+          <dl className="grid gap-2.5 text-sm">
+            <DetailRow
+              label="Status"
+              accentClass="bg-amber-50/80"
+              value={
+                <span
+                  className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-bold ${
+                    tutor.regFeePaid
+                      ? 'bg-emerald-500 text-white'
+                      : 'bg-slate-200 text-slate-700'
+                  }`}
+                >
+                  {tutor.regFeePaid ? 'Paid' : 'Not received'}
+                </span>
+              }
+            />
+            <DetailRow
+              label="Amount"
+              value={feeAmount != null ? `₹${feeAmount}` : '—'}
+              accentClass="bg-amber-50/80"
+            />
+            <DetailRow
+              label="Date received"
+              value={tutor.regFeePaid ? formatDate(tutor.regFeeDate) : 'Not received'}
+              accentClass="bg-amber-50/80"
+            />
+          </dl>
+        </SectionCard>
+      </div>
 
       {selectedDocument &&
         (isAdmin ? (


### PR DESCRIPTION
- Introduced GraphQL queries for fetching admin tutor calendar data and updated availability status.
- Enhanced TutorAvailabilityCalendar and TutorAvailabilitySection components to support admin view with read-only access.
- Updated TutorDetailView to conditionally render the tutor calendar based on availability and rate card status.
- Improved user experience by providing clear distinctions between admin and tutor views in the availability management interface.