### PR TITLE
Refactor Tutor Offering Label Formatting and Enhance Test Coverage

### DIFF
--- a/apps/api/src/app/modules/tutor/services/tutor-detail.service.ts
+++ b/apps/api/src/app/modules/tutor/services/tutor-detail.service.ts
@@ -195,19 +195,28 @@ export class TutorDetailService {
     offeringsById: Map<number, OfferingNodeForLabel>,
     proficiencyTestOfferingIds?: number[],
   ): AdminTutorOfferingDetail {
+    const catalogNode = offeringsById.get(offering.offeringId);
     const leaf = offering.offering
-      ? offeringsById.get(offering.offering.id) ??
-        this.toOfferingNodeForLabel(offering.offering)
-      : undefined;
+      ? {
+          ...(catalogNode ?? this.toOfferingNodeForLabel(offering.offering)),
+          displayName:
+            catalogNode?.displayName ??
+            offering.offering.displayName ??
+            offering.offering.name ??
+            'Offering',
+        }
+      : catalogNode;
+
+    const offeringFullLabel = formatTutorOfferingFullLabel(leaf, offeringsById, {
+      proficiencyTestOfferingIds,
+    });
 
     return {
       id: offering.id,
       offeringId: offering.offeringId,
       offeringName: offering.offering?.name,
       offeringDisplayName: offering.offering?.displayName,
-      offeringFullLabel: formatTutorOfferingFullLabel(leaf, offeringsById, {
-        proficiencyTestOfferingIds,
-      }),
+      offeringFullLabel,
       status: offering.status,
       attemptsUsed: offering.attemptsUsed,
       attemptsRemaining: Math.max(0, PT_MAX_ATTEMPTS - offering.attemptsUsed),

--- a/libs/shared-utils/src/tutor-offering-display.spec.ts
+++ b/libs/shared-utils/src/tutor-offering-display.spec.ts
@@ -129,7 +129,7 @@ describe('formatTutorOfferingFullLabel', () => {
       formatTutorOfferingFullLabel(leaf, byId, {
         proficiencyTestOfferingIds: [1001, 1000, 1005],
       }),
-    ).toBe('CBSE | English | Mathematics | Classes 1 - 5');
+    ).toBe('CBSE | Mathematics | Classes 1 - 5');
   });
 
   it('formats a single class when no PT offering list is provided', () => {
@@ -137,7 +137,7 @@ describe('formatTutorOfferingFullLabel', () => {
     const leaf = offeringFrom(byId, 1000);
 
     expect(formatTutorOfferingFullLabel(leaf, byId)).toBe(
-      'CBSE | English | Mathematics | Classes 4',
+      'CBSE | Mathematics | Classes 4',
     );
   });
 
@@ -148,6 +148,24 @@ describe('formatTutorOfferingFullLabel', () => {
     expect(formatTutorOfferingFullLabel(leaf, byId)).toBe(
       'CBSE | Hindi | Mathematics | Kindergarten',
     );
+  });
+
+  it('shows English as subject without duplicating English medium', () => {
+    const byId = buildSchoolEducationTree();
+    const englishLeaf = offering({
+      id: 3001,
+      displayName: 'English',
+      level: 3,
+      parentOffering: { id: 101 },
+      mediumOfInstruction: 1,
+    });
+    byId.set(englishLeaf.id, englishLeaf);
+
+    expect(
+      formatTutorOfferingFullLabel(englishLeaf, byId, {
+        proficiencyTestOfferingIds: [3001],
+      }),
+    ).toBe('CBSE | English | Classes 1');
   });
 
   it('formats non-school study areas with full path segments', () => {

--- a/libs/shared-utils/src/tutor-offering-display.ts
+++ b/libs/shared-utils/src/tutor-offering-display.ts
@@ -109,9 +109,33 @@ export function getOfferingAncestors(
   return ancestors;
 }
 
+const DEFAULT_MEDIUM_OF_INSTRUCTION = 1;
+
 function mediumLabel(medium?: number | null): string {
   if (medium == null) return MEDIUM_LABELS[1];
   return MEDIUM_LABELS[medium] ?? MEDIUM_LABELS[1];
+}
+
+/** Omit default English medium in labels so it is not confused with the English subject. */
+function formatMediumSegmentForLabel(medium?: number | null): string | null {
+  const moi = medium ?? DEFAULT_MEDIUM_OF_INSTRUCTION;
+  if (moi === DEFAULT_MEDIUM_OF_INSTRUCTION) {
+    return null;
+  }
+  return mediumLabel(moi);
+}
+
+function buildSchoolEducationLabel(
+  board: string,
+  subject: string,
+  classSegment: string,
+  medium?: number | null,
+): string {
+  const mediumSegment = formatMediumSegmentForLabel(medium);
+  if (mediumSegment) {
+    return joinLabelSegments(board, mediumSegment, subject, classSegment);
+  }
+  return joinLabelSegments(board, subject, classSegment);
 }
 
 /** Extract class number from labels like "Class 4", "class 11". */
@@ -183,7 +207,7 @@ function formatNonSchoolEducationLabel(
 
 /**
  * Build a full offering label for tutor profile tables.
- * School Education: "{board} | {medium} | {subject} | Classes {low} - {high}" from PT-linked offerings when available.
+ * School Education: "{board} | {subject} | Classes {low} - {high}" (non-English medium shown before subject).
  * Other study areas: space-separated path without the root study area name.
  */
 export function formatTutorOfferingFullLabel(
@@ -224,16 +248,16 @@ function formatSchoolEducationLabelWithCatalog(
   offeringsById: Map<number, OfferingNodeForLabel>,
   options?: TutorOfferingLabelOptions,
 ): string {
-  const medium = mediumLabel(leaf.mediumOfInstruction);
+  const subject = leaf.displayName?.trim() || 'Offering';
   const board = ancestors[1]?.displayName;
   const grade = ancestors[2]?.displayName;
 
   if (!board) {
-    return leaf.displayName;
+    return subject;
   }
 
   if (!grade) {
-    return joinLabelSegments(board, medium, leaf.displayName);
+    return buildSchoolEducationLabel(board, subject, subject, leaf.mediumOfInstruction);
   }
 
   const groupKey = schoolEducationGroupKey(leaf, ancestors);
@@ -247,19 +271,24 @@ function formatSchoolEducationLabelWithCatalog(
     );
     const rangeLabel = formatClassRangeLabel(classNumbers);
     if (rangeLabel) {
-      return joinLabelSegments(board, medium, leaf.displayName, rangeLabel);
+      return buildSchoolEducationLabel(
+        board,
+        subject,
+        rangeLabel,
+        leaf.mediumOfInstruction,
+      );
     }
   }
 
   const classNum = parseClassNumber(grade);
   if (classNum != null) {
-    return joinLabelSegments(
+    return buildSchoolEducationLabel(
       board,
-      medium,
-      leaf.displayName,
+      subject,
       `Classes ${classNum}`,
+      leaf.mediumOfInstruction,
     );
   }
 
-  return joinLabelSegments(board, medium, leaf.displayName, grade);
+  return buildSchoolEducationLabel(board, subject, grade, leaf.mediumOfInstruction);
 }


### PR DESCRIPTION
- Updated the `formatTutorOfferingFullLabel` function to omit the default English medium in labels, preventing confusion with the English subject.
- Introduced a new helper function to streamline medium segment formatting.
- Enhanced unit tests to cover scenarios for English subjects and ensure accurate label formatting.
- Improved readability and maintainability of the tutor offering display logic.